### PR TITLE
Parse URL Variables

### DIFF
--- a/postmanparser/url.py
+++ b/postmanparser/url.py
@@ -30,7 +30,7 @@ class Url:
         if query:
             query = [KeyVal.parse(_) for _ in query]
 
-        variable = data.get("variable", None)
+        variable = data.get("variable", [])
         if variable:
             variable = [Variable.parse(_) for _ in variable]
 

--- a/postmanparser/url.py
+++ b/postmanparser/url.py
@@ -25,9 +25,15 @@ class Url:
             port = "80"
         if protocol == "https":
             port = "443"
+
         query = data.get("query", None)
         if query:
             query = [KeyVal.parse(_) for _ in query]
+
+        variable = data.get("variable", None)
+        if variable:
+            variable = [Variable.parse(_) for _ in variable]
+
         return cls(
             data.get("raw", ""),
             data.get("protocol", ""),
@@ -36,4 +42,5 @@ class Url:
             path=data.get("path", ""),
             query=query,
             url_hash=data.get("hash", ""),
+            variable=variable,
         )

--- a/tests/test_collection_url_variable.py
+++ b/tests/test_collection_url_variable.py
@@ -38,7 +38,7 @@ def test_get_url_variables():
     assert url.variable[0].value == "1"
 
 
-def test_empty_variabes_should_return_none(collection):
+def test_empty_variables_should_return_empty_list(collection):
     _collection = {
         "info": {
             "_postman_id": "9c76aeae-011c-4327-96c4-17146aacd14d",
@@ -69,4 +69,4 @@ def test_empty_variabes_should_return_none(collection):
     assert len(collection.item) == 1
 
     url = collection.item[0].request.url
-    assert url.variable is None
+    assert url.variable == []

--- a/tests/test_collection_url_variable.py
+++ b/tests/test_collection_url_variable.py
@@ -1,0 +1,71 @@
+from postmanparser.collection import Collection
+
+
+def test_get_url_variables():
+    _collection = {
+        "info": {
+            "_postman_id": "9c76aeae-011c-4327-96c4-17146aacd14d",
+            "name": "example",
+            "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+        },
+        "item": [{
+            "name": "example",
+            "request": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                    "raw": "https://example.com/status/:id",
+                    "protocol": "https",
+                    "host": ["example", "com"],
+                    "path": ["status", ":id"],
+                    "variable": [{
+                        "key": "id",
+                        "value": "1"
+                    }]
+                }
+            },
+            "response": []
+        }]
+    }
+
+    collection = Collection()
+    collection.parse(_collection)
+
+    assert len(collection.item) == 1
+
+    url = collection.item[0].request.url
+    assert isinstance(url.variable, list) and len(url.variable) == 1
+    assert url.variable[0].key == "id"
+    assert url.variable[0].value == "1"
+
+
+def test_empty_variabes_should_return_none(collection):
+    _collection = {
+        "info": {
+            "_postman_id": "9c76aeae-011c-4327-96c4-17146aacd14d",
+            "name": "example",
+            "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+        },
+        "item": [{
+            "name": "example",
+            "request": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                    "raw": "https://example.com/status/",
+                    "protocol": "https",
+                    "host": ["example", "com"],
+                    "path": ["status"]
+                }
+            },
+            "response": []
+        }]
+    }
+
+    collection = Collection()
+    collection.parse(_collection)
+
+    assert len(collection.item) == 1
+
+    url = collection.item[0].request.url
+    assert url.variable is None

--- a/tests/test_collection_url_variable.py
+++ b/tests/test_collection_url_variable.py
@@ -6,26 +6,25 @@ def test_get_url_variables():
         "info": {
             "_postman_id": "9c76aeae-011c-4327-96c4-17146aacd14d",
             "name": "example",
-            "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+            "schema": "https://schema.postman.com/#2.0.0",
         },
-        "item": [{
-            "name": "example",
-            "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                    "raw": "https://example.com/status/:id",
-                    "protocol": "https",
-                    "host": ["example", "com"],
-                    "path": ["status", ":id"],
-                    "variable": [{
-                        "key": "id",
-                        "value": "1"
-                    }]
-                }
-            },
-            "response": []
-        }]
+        "item": [
+            {
+                "name": "example",
+                "request": {
+                    "method": "GET",
+                    "header": [],
+                    "url": {
+                        "raw": "https://example.com/status/:id",
+                        "protocol": "https",
+                        "host": ["example", "com"],
+                        "path": ["status", ":id"],
+                        "variable": [{"key": "id", "value": "1"}],
+                    },
+                },
+                "response": [],
+            }
+        ],
     }
 
     collection = Collection()
@@ -44,22 +43,24 @@ def test_empty_variabes_should_return_none(collection):
         "info": {
             "_postman_id": "9c76aeae-011c-4327-96c4-17146aacd14d",
             "name": "example",
-            "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+            "schema": "https://schema.postman.com/#2.0.0",
         },
-        "item": [{
-            "name": "example",
-            "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                    "raw": "https://example.com/status/",
-                    "protocol": "https",
-                    "host": ["example", "com"],
-                    "path": ["status"]
-                }
-            },
-            "response": []
-        }]
+        "item": [
+            {
+                "name": "example",
+                "request": {
+                    "method": "GET",
+                    "header": [],
+                    "url": {
+                        "raw": "https://example.com/status/",
+                        "protocol": "https",
+                        "host": ["example", "com"],
+                        "path": ["status"],
+                    },
+                },
+                "response": [],
+            }
+        ],
     }
 
     collection = Collection()


### PR DESCRIPTION
Hey,
In order to support path parameters (for example `https://hello.com/example/:someting`), Postman uses URL variables.
It is essentially a list of `Variable` inside the `Url` object.
There was a declaration for the `variable` property, but was not parsed.

Therefore, I am adding support for it. 😄 

I've tried to follow your code style. Let me know if you've got any problem.