### PR TITLE
Update pyproject.toml to use a modern httpx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-httpx = "^0.18.1"
+httpx = "^0.27.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
This library messes up a modern Python stack because https `0.18` is way old, 3 years.